### PR TITLE
Seeding Implemented Via Seedie Gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'dartsass-sprockets'
 # Form handler
 gem 'simple_form'
 
+# Seeding
+gem 'seedie'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     drb (2.2.1)
     erubi (1.12.0)
     execjs (2.9.1)
+    faker (3.3.1)
+      i18n (>= 1.8.11, < 2)
     globalid (1.2.1)
       activesupport (>= 6.1)
     google-protobuf (4.26.1)
@@ -264,6 +266,10 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sassc-embedded (1.76.0)
       sass-embedded (~> 1.76)
+    seedie (0.4.0)
+      activerecord (>= 5.2.0)
+      faker (>= 2.9)
+      zeitwerk (~> 2.4)
     selenium-webdriver (4.20.1)
       base64 (~> 0.2)
       rexml (~> 3.2, >= 3.2.5)
@@ -341,6 +347,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  seedie
   selenium-webdriver
   sidekiq
   sidekiq-failures

--- a/app/models/kilo.rb
+++ b/app/models/kilo.rb
@@ -1,6 +1,8 @@
 class Kilo < ApplicationRecord
   validates :title, presence: true
-  validates :body, presence: true, length: { minimum: 10, maximum: 50 }
+  validates :body, presence: true, length: { minimum: 2, maximum: 50 }
 
-  def to_s = title
+  def to_s
+    title
+  end
 end

--- a/config/initializers/seedie.rb
+++ b/config/initializers/seedie.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Seedie.configure do |config|
+  # config.default_count = 10
+
+  config.custom_attributes[:email] = "{{Faker::Internet.unique.email}}"
+  # Add more custom attributes here
+end

--- a/config/seedie.yml
+++ b/config/seedie.yml
@@ -1,0 +1,22 @@
+default_count: 5
+models:
+  kilo:
+    attributes:
+      title: '{{Faker::Lorem.word}}'
+      body: '{{Faker::Lorem.word}}'
+    disabled_fields: []
+    associations:
+      belongs_to:
+      has_one:
+      has_many:
+  user:
+    count: 3
+    attributes:
+      email: '{{Faker::Lorem.unique.word}}@example.com'
+      encrypted_password: 'qui'
+      password: 'seedie'
+    disabled_fields: ["reset_password_token", "reset_password_sent_at", "remember_created_at"]
+    associations:
+      belongs_to:
+      has_one:
+      has_many:


### PR DESCRIPTION
Latest version of Seedie gem (0.4.0) has been added to the Gemfile and installed via the standard Seedie generator command.

5 Kilo records and 3 Users are now created when
rake seedie:seed is ran as a Rake task.

A smaller character minimum amount has been placed to allow Seedie to create the body of Kilo seeds in its current format.

There is potential to expand this into a more complex seed tool later on, including more intricate seeds per model and matching up with expanded models.

Also separately adjusted the method format of the to_s method for the kilo title.