### PR TITLE
Added Weight to Kilo

### DIFF
--- a/app/controllers/kilos_controller.rb
+++ b/app/controllers/kilos_controller.rb
@@ -1,5 +1,5 @@
 class KilosController < ApplicationController
-  # Will specify CRUD actions later, for now adding to thiis will affect Turbo
+  # Will specify CRUD actions later, for now adding to this line below will affect Turbo
   skip_before_action :authenticate_user!
 
   def index
@@ -38,6 +38,6 @@ class KilosController < ApplicationController
   private
 
   def kilo_params
-    params.require(:kilo).permit(:title, :body)
+    params.require(:kilo).permit(:title, :body, :weight)
   end
 end

--- a/app/models/kilo.rb
+++ b/app/models/kilo.rb
@@ -1,4 +1,5 @@
 class Kilo < ApplicationRecord
+  validates :weight, presence: true, numericality: { greater_than: 0 }
   validates :title, presence: true
   validates :body, presence: true, length: { minimum: 2, maximum: 50 }
 

--- a/app/views/kilos/_form.html.erb
+++ b/app/views/kilos/_form.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for @kilo do |f| %>
   <%= f.input :title %>
   <%= f.input :body %>
+  <%= f.input :weight, step: 0.01 %>
   <%= f.button :submit %>
 <% end %>

--- a/app/views/kilos/new.html.erb
+++ b/app/views/kilos/new.html.erb
@@ -1,1 +1,8 @@
-<p>New Template for New Kilo Create Attempt</p>
+<h1>New Kilo Record</h1>
+
+<%= simple_form_for @kilo do |f| %>
+  <%= f.input :title %>
+  <%= f.input :body %>
+  <%= f.input :weight, step: 0.01 %>
+  <%= f.button :submit %>
+<% end %>

--- a/app/views/kilos/show.html.erb
+++ b/app/views/kilos/show.html.erb
@@ -2,5 +2,6 @@
   <%= turbo_stream_from dom_id(@kilo) %>
   <h1><%= @kilo.title %></h1>
   <p><%= @kilo.body %></p>
+  <p>Weight: <%= number_with_precision(@kilo.weight, precision: 2) %> kg</p>
   <%= link_to 'Back', kilos_path %>
 <% end %>

--- a/db/migrate/20240510190354_add_weight_to_kilos.rb
+++ b/db/migrate/20240510190354_add_weight_to_kilos.rb
@@ -1,0 +1,5 @@
+class AddWeightToKilos < ActiveRecord::Migration[7.1]
+  def change
+    add_column :kilos, :weight, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_135012) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_10_190354) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_135012) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "weight"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Weight now exists with the Kilo architecture, as a numerical value that needs to be passed into a Kilo record now to create a record.

Added weight as an input in the new view and form partials, and also appear as per the weight specified in the record in the kilo show page. Parameter added to the private method in the kilos_controller also.

Confirmed that weights will appear from records created both in the Rails console and the localhost server.

Updated commented instruction code in the kilos_controller.