### PR TITLE
pg_search gem installed and setup in the kilo model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,9 @@ gem 'simple_form'
 # Seeding
 gem 'seedie'
 
+# Search gem
+gem 'pg_search'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,9 @@ GEM
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.5.6)
+    pg_search (2.3.6)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     popper_js (2.11.8)
     psych (5.1.2)
       stringio
@@ -345,6 +348,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   pg (~> 1.1)
+  pg_search
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   seedie

--- a/app/models/kilo.rb
+++ b/app/models/kilo.rb
@@ -1,4 +1,7 @@
 class Kilo < ApplicationRecord
+  include PgSearch::Model
+  multisearchable against: [:weight, :title, :body]
+
   validates :weight, presence: true, numericality: { greater_than: 0 }
   validates :title, presence: true
   validates :body, presence: true, length: { minimum: 2, maximum: 50 }

--- a/db/migrate/20240512180036_create_pg_search_documents.rb
+++ b/db/migrate/20240512180036_create_pg_search_documents.rb
@@ -1,0 +1,17 @@
+class CreatePgSearchDocuments < ActiveRecord::Migration[7.1]
+  def up
+    say_with_time("Creating table for pg_search multisearch") do
+      create_table :pg_search_documents do |t|
+        t.text :content
+        t.belongs_to :searchable, polymorphic: true, index: true
+        t.timestamps null: false
+      end
+    end
+  end
+
+  def down
+    say_with_time("Dropping table for pg_search multisearch") do
+      drop_table :pg_search_documents
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_10_190354) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_12_180036) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "infinites", force: :cascade do |t|
+    t.integer "count"
+    t.float "price"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "kilos", force: :cascade do |t|
     t.string "title"
@@ -20,6 +27,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_10_190354) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.float "weight"
+  end
+
+  create_table "pg_search_documents", force: :cascade do |t|
+    t.text "content"
+    t.string "searchable_type"
+    t.bigint "searchable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["searchable_type", "searchable_id"], name: "index_pg_search_documents_on_searchable"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Latest version of the pg_search gem has been setup to handle search functionality within the application. Integrated the gems model search ability within the Kilo model, and made an array of all current Kilo parameters to make them all searchable via pg_search.

Implemented pg_search multisearch so that "one global index is created for all the active record classes" according to https://www.mintbit.com/blog/searching-made-easy-with-pg-search-gem-in-ruby-on-rails.

Records can be searched in the console via the PgSearch.multisearch("example").