### PR TITLE
Modal with Popover inside the Modal Added to Kilos Index Page

### DIFF
--- a/app/views/kilos/index.html.erb
+++ b/app/views/kilos/index.html.erb
@@ -20,4 +20,24 @@
   </button>
 
   <%= render "kilos/form" %>
+
+  <div class="modal fade" id="exampleModalXl" tabindex="-1" aria-labelledby="exampleModalXlLabel" style="display: none;" aria-hidden="true">
+    <div class="modal-dialog modal-xl">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h1 class="modal-title fs-4" id="exampleModalXlLabel">Kilos...</h1>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <h2 class="fs-5">This is the Kilos side of the application...</h2>
+          <p>This <button class="btn btn-secondary" data-bs-toggle="popover" title="Popover title" data-bs-content="Popover body content is set in this attribute.">button</button> triggers a popover on click.</p>
+          <hr>
+          <h2 class="fs-5">Kilos modal with a popover in the modal above</h2>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
+  <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModalXl">Kilos...</button>
 </div>


### PR DESCRIPTION
A Bootstrap modal with a popover inside the opened modal has been added to demonstrate the depth of which a single webpage can be customised without the browser reloading or redirecting to a different webpage.

This new Bootstrap modal with a openable popover exists within the Kilos index page/current application homepage.