### PR TITLE
Action Policy Gem Added to the Application

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,9 @@ gem 'seedie'
 # Search gem
 gem 'pg_search'
 
+# Authorisation gem
+gem "action_policy"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    action_policy (0.6.9)
+      ruby-next-core (>= 1.0)
     actioncable (7.1.3.3)
       actionpack (= 7.1.3.3)
       activesupport (= 7.1.3.3)
@@ -246,6 +248,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    ruby-next-core (1.0.3)
     rubyzip (2.3.2)
     sass-embedded (1.77.0-aarch64-linux-gnu)
       google-protobuf (>= 3.25, < 5.0)
@@ -339,6 +342,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  action_policy
   bootsnap
   bootstrap (~> 5.3.3)
   capybara

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,18 @@
+# Base class for application policies
+class ApplicationPolicy < ActionPolicy::Base
+  # Configure additional authorization contexts here
+  # (`user` is added by default).
+  #
+  #   authorize :account, optional: true
+  #
+  # Read more about authorization context: https://actionpolicy.evilmartians.io/#/authorization_context
+
+  private
+
+  # Define shared methods useful for most policies.
+  # For example:
+  #
+  #  def owner?
+  #    record.user_id == user.id
+  #  end
+end

--- a/app/policies/kilo_policy.rb
+++ b/app/policies/kilo_policy.rb
@@ -1,0 +1,20 @@
+class KiloPolicy < ApplicationPolicy
+  # See https://actionpolicy.evilmartians.io/#/writing_policies
+  #
+  def index?
+    true
+  end
+  #
+  # def update?
+  #   # here we can access our context and record
+  #   user.admin? || (user.id == record.user_id)
+  # end
+
+  # Scoping
+  # See https://actionpolicy.evilmartians.io/#/scoping
+  #
+  # relation_scope do |relation|
+  #   next relation if user.admin?
+  #   relation.where(user: user)
+  # end
+end

--- a/test/policies/kilo_policy_test.rb
+++ b/test/policies/kilo_policy_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+# See https://actionpolicy.evilmartians.io/#/testing?id=testing-policies
+class KiloPolicyTest < ActiveSupport::TestCase
+  def test_index
+  end
+
+  def test_create
+  end
+
+  def test_manage
+  end
+end


### PR DESCRIPTION
Authorisation gem Action Policy has been added to the application to control user activity.

The latest version of the action_policy gem has been installed (0.6.9).

A Kilo policy file has been generated and added so that all users are allowed to perform "index" activities for the Kilo section of the application.