### PR TITLE
Expanded the Infinite MVC and Added Turbo to it

### DIFF
--- a/app/assets/stylesheets/_infinites.scss
+++ b/app/assets/stylesheets/_infinites.scss
@@ -1,0 +1,4 @@
+// .product-details-header {
+//   font-size: 1.5em;
+//   margin-bottom: 10px;
+// }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,5 @@
  @import "bootstrap";
 
  @import "variables";
+
+ @import "infinites";

--- a/app/controllers/infinites_controller.rb
+++ b/app/controllers/infinites_controller.rb
@@ -11,16 +11,30 @@ class InfinitesController < ApplicationController
 
   def new
     @infinite = Infinite.new
+    respond_to do |format|
+      format.html
+      format.turbo_stream
+    end
   end
 
   def create
     @infinite = Infinite.new(infinite_params)
+
+    respond_to do |format|
+      if @infinite.save
+        format.html { redirect_to @infinite, notice: "Infinite was successfully created." }
+        format.turbo_stream { render turbo_stream: turbo_stream.prepend(:infinites, partial: 'infinite', locals: { infinite: @infinite }) }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.turbo_stream { render turbo_stream: turbo_stream.replace(@infinite, partial: 'form', locals: { infinite: @infinite }) }
+      end
+    end
   end
 
 
   private
 
   def infinite_params
-    params.require(:infinite).permit(:name, :count, :price)
+    params.require(:infinite).permit(:name, :count, :price, :description, :image)
   end
 end

--- a/app/models/infinite.rb
+++ b/app/models/infinite.rb
@@ -5,6 +5,8 @@ class Infinite < ApplicationRecord
   validates :name, presence: true
   validates :count, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
   validates :price, numericality: { greater_than_or_equal_to: 0.0 }
+  validates :description, presence: true
+  has_one_attached :image
 
   scope :available, -> { where('count > 0') }
   scope :expensive, -> { where('price > 100') }

--- a/app/views/infinites/_form.html.erb
+++ b/app/views/infinites/_form.html.erb
@@ -13,6 +13,14 @@
       <%= f.input :price, step: 0.01 %>
     </div>
 
+    <div class="mb-3">
+      <%= f.input :image, as: :file %>
+    </div>
+
+    <div class="mb-3">
+      <%= f.input :description %>
+    </div>
+
     <%= f.button :submit %>
   </div>
 <% end %>

--- a/app/views/infinites/_infinite.html.erb
+++ b/app/views/infinites/_infinite.html.erb
@@ -1,0 +1,7 @@
+<%= turbo_frame_tag dom_id(infinite) do %>
+  <%= link_to infinite_path(infinite), data: { turbo_frame: "infinite_#{infinite.id}" } do %>
+    <h2><%= infinite.name %></h2>
+    <p>Price: <%= number_to_currency(infinite.price) %></p>
+    <p>Quantity: <%= infinite.count %></p>
+  <% end %>
+<% end %>

--- a/app/views/infinites/index.html.erb
+++ b/app/views/infinites/index.html.erb
@@ -1,7 +1,11 @@
 <h1>Infinite Products</h1>
-<% @infinites.each do |infinite| %>
-  <%= link_to infinite.name, infinite_path(infinite), data: { turbo_frame: "infinite_#{infinite.id}" } %>
-<% end %>
 
+<%= turbo_stream_from :infinites %>
 
-  <%= render "infinites/form" %>
+<div class="infinite-index-container">
+  <% @infinites.each do |infinite| %>
+    <%= render partial: 'infinite', locals: { infinite: infinite } %>
+  <% end %>
+</div>
+
+<%= turbo_frame_tag "new_infinite", src: new_infinite_path %>

--- a/app/views/infinites/new.html.erb
+++ b/app/views/infinites/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Infinite</h1>
+
+<%= turbo_frame_tag "new_infinite" do %>
+  <%= render partial: 'form', locals: { infinite: @infinite } %>
+<% end %>

--- a/app/views/infinites/new.turbo_stream.erb
+++ b/app/views/infinites/new.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "new_infinite" do %>
+  <%= render partial: 'form', locals: { infinite: @infinite } %>
+<% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,6 +13,10 @@
           <li class="nav-item">
             <a class="nav-link" href="#">Kilo</a>
           </li>
+          <li class="nav-item">
+            <%= link_to "Infinites", infinites_path, class: "nav-link" %>
+          </li>
+          
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               TBD

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,7 @@ Rails.application.routes.draw do
 
   resources :kilos
 
-  resources :infinites, only: [:index, :show]
-
+  resources :infinites
 
   #Background jobs routes
   require "sidekiq/web"

--- a/db/migrate/20240607185116_add_description_to_infinites.rb
+++ b/db/migrate/20240607185116_add_description_to_infinites.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToInfinites < ActiveRecord::Migration[7.2]
+  def change
+    add_column :infinites, :description, :text
+  end
+end

--- a/db/migrate/20240607190141_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20240607190141_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_14_190014) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_07_190141) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "infinites", force: :cascade do |t|
     t.integer "count"
@@ -20,6 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_190014) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.text "description"
   end
 
   create_table "kilos", force: :cascade do |t|
@@ -51,4 +80,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_14_190014) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
Turbo Streams have now been integrated into the Infinite views and controller,
 and the model has also been expanded with the inclusion of images and descriptions
 to be capable of being added to Infinite records.

 Schema migrations performed to add the new schema files for expanding the
 infinite MVC.

 Removed infinites routes restrictions to allow new and create, as previously
 only index and show were permitted in the routes.

Infinite index page link added to the navbar.

Form expanded with the inclusion of new image (sourcing from Active Storage) and description parameters, the same have been added to the private infinite controller method.

Added base css for infinite, however this is commented out for now until further is added to it.