### PR TITLE
Deletion of Records now possible within Kilo and Infinite

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Gems such as Action Policy for authorisation and Bundler Audit along with Brakem
 
 Upgraded to Rails 7.2 Beta and latest Ruby version (3.3.3).
 
-#### Arriving Soon
+Inclusion of deletion CRUD action in both Kilo and Infinite sections of the application.
 
-Inclusion of deletion CRUD action in both Kilo and Infinite sectionss of the application.
+#### Arriving Soon
 
 Further models and controllers, as not looking to create extensively comprehensive versions of them.
 

--- a/app/controllers/infinites_controller.rb
+++ b/app/controllers/infinites_controller.rb
@@ -32,6 +32,12 @@ class InfinitesController < ApplicationController
     end
   end
 
+  def destroy
+    @infinite = Infinite.find(params[:id])
+    @infinite.destroy
+    redirect_to infinites_path, status: :see_other
+  end
+
 
   private
 

--- a/app/controllers/kilos_controller.rb
+++ b/app/controllers/kilos_controller.rb
@@ -32,7 +32,9 @@ class KilosController < ApplicationController
   end
 
   def destroy
+    @kilo = Kilo.find(params[:id])
     @kilo.destroy
+    redirect_to kilos_path, status: :see_other
   end
 
   private

--- a/app/views/infinites/show.html.erb
+++ b/app/views/infinites/show.html.erb
@@ -5,3 +5,8 @@
 <%= @infinite.price %>
 
 <%= @infinite.count %>
+
+<%= link_to "Delete",
+  infinite_path(@infinite),
+  data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}
+%>

--- a/app/views/kilos/show.html.erb
+++ b/app/views/kilos/show.html.erb
@@ -5,3 +5,8 @@
   <p>Weight: <%= number_with_precision(@kilo.weight, precision: 2) %> kg</p>
   <%= link_to 'Back', kilos_path %>
 <% end %>
+
+<%= link_to "Delete",
+  kilo_path(@kilo),
+  data: {turbo_method: :delete, turbo_confirm: "Are you sure?"}
+%>


### PR DESCRIPTION
Turbo deletion actions have been added to the frontend show pages for individual kilo and infinite records. Once a record is clicked on and deleted the logged in user (login is required for this) is redirected to the respective index page (either kilo or infinite depending on whether a kilo or infinite record was deleted). The user is also prompted upon pressing the delete link if they wish to proceed, ensuring records are not accidentally deleted.

The kilo and infinite controllers have also been updated to allow the deletions to occur, with both controllers having a method to find the specific record the user wishes to delete before then deleting it.

Revised the README document also to accommodate for the change that has taken place.