### PR TITLE
Added to Enigma and User Models and Created an Enigma Rating Model

### DIFF
--- a/app/models/enigma.rb
+++ b/app/models/enigma.rb
@@ -1,4 +1,10 @@
 class Enigma < ApplicationRecord
   validates :paradox, presence: true, uniqueness: true
-  validates :body, presence: true
+  validates :body, length: { minimum: 20 }, presence: true
+
+  has_many :enigma_ratings
+
+  def average_rating
+    enigma_ratings.average(:rating).to_f # to_f added to avoid integer division
+  end
 end

--- a/app/models/enigma_rating.rb
+++ b/app/models/enigma_rating.rb
@@ -1,0 +1,9 @@
+class EnigmaRating < ApplicationRecord
+  belongs_to :enigma
+  belongs_to :user
+
+  validates :enigma, presence: true
+  validates :user, presence: true
+  validates :rating, presence: true
+  validates :enigma_id, uniqueness: { scope: :user_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :enigma_ratings
 end

--- a/db/migrate/20240616152014_create_enigma_ratings.rb
+++ b/db/migrate/20240616152014_create_enigma_ratings.rb
@@ -1,0 +1,11 @@
+class CreateEnigmaRatings < ActiveRecord::Migration[7.2]
+  def change
+    create_table :enigma_ratings do |t|
+      t.references :enigma, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.integer :rating
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_15_131812) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_16_152014) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,16 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_15_131812) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "enigma_ratings", force: :cascade do |t|
+    t.bigint "enigma_id", null: false
+    t.bigint "user_id", null: false
+    t.integer "rating"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["enigma_id"], name: "index_enigma_ratings_on_enigma_id"
+    t.index ["user_id"], name: "index_enigma_ratings_on_user_id"
   end
 
   create_table "enigmas", force: :cascade do |t|
@@ -89,4 +99,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_15_131812) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "enigma_ratings", "enigmas"
+  add_foreign_key "enigma_ratings", "users"
 end

--- a/spec/factories/enigma_ratings.rb
+++ b/spec/factories/enigma_ratings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :enigma_rating do
+    enigma { nil }
+    user { nil }
+    rating { 1 }
+  end
+end

--- a/spec/models/enigma_rating_spec.rb
+++ b/spec/models/enigma_rating_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EnigmaRating, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Looking to integrate a rating system into Engima, rather than make it an overflowing model, I chose to create a new Engima Rating model to handle the ratings and then call it in the Engima and User model to provide the relationship with them.

Validations and relationships have been setup in the new enigma rating model, the initial generated enigma rating migration file has been migrated into the database schema also.

In the enigma model a new method has been setup linked with the enigma ratings to work out an average rating, I will look to implement this in the view in the future based on the average of enigma rating records.