### PR TITLE
User Expanded with First and Last Name Fields

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,5 +4,13 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
+
+  def name
+    "#{first_name} #{last_name}"
+  end
+
+  validates :email, presence: true, length: { maximum: 200 }
+  validates :password, presence: true, length: { minimum: 6 }
+
   has_many :enigma_ratings
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,6 +10,17 @@
     </div>
 
     <div class="form-field">
+      <%= f.label :first_name %>
+      <%= f.text_field :first_name, class: "input-field" %>
+    </div>
+
+    <div class="form-field">
+      <%= f.label :last_name %>
+      <%= f.text_field :last_name, class: "input-field" %>
+    </div>
+
+
+    <div class="form-field">
       <%= f.label :password %>
       <% if @minimum_password_length %>
         <em class="password-hint">(<%= @minimum_password_length %> characters minimum)</em>

--- a/db/migrate/20240617192641_add_name_to_users.rb
+++ b/db/migrate/20240617192641_add_name_to_users.rb
@@ -1,0 +1,5 @@
+class AddNameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :name, :string
+  end
+end

--- a/db/migrate/20240617192813_add_first_and_last_name_to_users.rb
+++ b/db/migrate/20240617192813_add_first_and_last_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddFirstAndLastNameToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_06_16_152014) do
+ActiveRecord::Schema[7.2].define(version: 2024_06_17_192813) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,9 @@ ActiveRecord::Schema[7.2].define(version: 2024_06_16_152014) do
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "name"
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
The user model and Devise sign up view have been expanded with the inclusion of first and last name fields, along with validations inserted for the already existing email and password fields, to ensure they are not extremely long in length and likely not an email/password.

The Devise view has had both first and last name fields added to it for when users sign up for the application.

A method for the new inclusion of first and last name for a user has been setup in the user model as "name".

Migration files have been created for both adding a name to a user and first and last name to a user, these have both been independently of each other before being migrated into the DB schema.